### PR TITLE
Add support for redirecting all of builders/* paths to a separate builders.m.o domain

### DIFF
--- a/birdbox/birdbox/urls.py
+++ b/birdbox/birdbox/urls.py
@@ -5,7 +5,7 @@
 from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse, HttpResponseForbidden
-from django.urls import include, path
+from django.urls import include, path, re_path
 from django.utils.module_loading import import_string
 from django.views.defaults import permission_denied
 
@@ -18,7 +18,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from watchman import views as watchman_views
 
-from common.views import csrf_failure, rate_limited
+from common.views import csrf_failure, rate_limited, redirect_view
 from microsite import urls as microsite_urls
 
 handler500 = "common.views.server_error_view"
@@ -39,6 +39,7 @@ urlpatterns = [
     path("documents/", include(wagtaildocs_urls)),
     path("healthz/", watchman_views.ping, name="watchman.ping"),
     path("readiness/", watchman_views.status, name="watchman.status"),
+    re_path("^builders/", redirect_view, {"dest": "https://builders.mozilla.org"}),
     path("", include(microsite_urls)),
     path(
         "robots.txt",

--- a/birdbox/common/views.py
+++ b/birdbox/common/views.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
@@ -26,3 +27,7 @@ def rate_limited(request, exception):
     response = render(request, "429.html", status=429)
     response["Retry-After"] = "60"
     return response
+
+
+def redirect_view(request, **kwargs):
+    return HttpResponsePermanentRedirect(kwargs["dest"])


### PR DESCRIPTION
As discussed in the Slacks